### PR TITLE
:bug: Get service PID at the correct moment.

### DIFF
--- a/task.json
+++ b/task.json
@@ -12,8 +12,8 @@
   "demands": [],
   "version": {
     "Major": "0",
-    "Minor": "0",
-    "Patch": "9"
+    "Minor": "1",
+    "Patch": "10"
   },
   "minimumAgentVersion": "1.95.0",
   "instanceNameFormat": "Stop Service $(ServiceName)",
@@ -53,11 +53,11 @@
     {
       "name": "KillService",
       "type": "boolean",
-      "label": "Kill service if stop fails",
+      "label": "Kill service process if not gracefully exited",
       "defaultValue": true,      
       "required": false,
       "groupName": "Advanced",
-      "helpMarkDown": "Select this option for force terminate the service if the stop fails."
+      "helpMarkDown": "Select this option for force terminate the service process if still running after service stop."
     }
   ],
   "execution": {

--- a/tests/StopWindowsService.Tests.ps1
+++ b/tests/StopWindowsService.Tests.ps1
@@ -21,9 +21,8 @@ Describe "Main" {
     Mock Get-VstsInput -ParameterFilter { $Name -eq "KillService" } -MockWith { return $false }
     Mock Test-ServiceExists -MockWith { return $true }
     Mock Write-Host -MockWith {}
-    Mock Test-ServiceProcessStopped -MockWith { return $true}
     Mock Stop-WindowsService -MockWith { }
-
+    Mock Get-ServiceProcessId -MockWith { return $false }
     Context "When service exists" {
         # Arrange
         Mock Test-ServiceExists -MockWith { return $true } 
@@ -54,13 +53,13 @@ Describe "Main" {
 
 
     Context "When fails to stop service gracefullly" {
-        Mock Test-ServiceProcessStopped -MockWith { return $false}
+        Mock Get-Process -MockWith { return $true }
+        $expectedPID = -1
+        Mock Get-ServiceProcessId -MockWith { return $expectedPID}
 
         It "Given kill flag is true, it should be killed." {
             # Arrange
             Mock Get-VstsInput -ParameterFilter { $Name -eq "KillService" } -MockWith { return $true }
-            $expectedPID = -1
-            Mock Get-ServiceProcessId -MockWith { return $expectedPID}
             Mock Stop-Process -MockWith {}
 
             # Act


### PR DESCRIPTION
Fix script to avoid process kill failure for PID 0(zero).

When getting service process Id after the service has been stopped sometimes the wmi query returns PID 0(invalid), even if the process still locking files.