### PR TITLE
 remove -Force argument from Stop-Service

### DIFF
--- a/StopWindowsService.ps1
+++ b/StopWindowsService.ps1
@@ -9,7 +9,7 @@ function Stop-WindowsService($serviceName, $timeout) {
 
         $status = "Stopped"
         $service = Get-Service $serviceName
-        Stop-Service $service -Force
+        Stop-Service $service
 
         Write-Host "Stop timeout: $timeout"
         $service.WaitForStatus($status, $timeout) | Out-Null


### PR DESCRIPTION
The -force parameter is crashing the pipeline.
Removing this parameter the service can be stopped gracefully.